### PR TITLE
Use `pin-project-lite`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-pin-project = "1.0"
+pin-project-lite = "0.2"
 tokio = { version = "1.0", features = ["time"] }
 
 [dev-dependencies]


### PR DESCRIPTION
This should make the build faster if the downstream crate does not have proc-macro dependencies.